### PR TITLE
avextensions: Fix warnings on 64-bit clang

### DIFF
--- a/media/libavextensions/common/ExtensionsLoader.hpp
+++ b/media/libavextensions/common/ExtensionsLoader.hpp
@@ -49,7 +49,7 @@ static const char * CUSTOMIZATION_LIB_NAME = "libavenhancements.so";
 
 template <typename T>
 T *ExtensionsLoader<T>::createInstance(const char *createFunctionName) {
-        ALOGV("createInstance(%dbit) : %s", sizeof(intptr_t)*8, createFunctionName);
+        (void)createFunctionName;
         // create extended object if extensions-lib is available and
         // AV_ENHANCEMENTS is enabled
 #if ENABLE_AV_ENHANCEMENTS

--- a/media/libavextensions/mediaplayerservice/AVNuUtils.cpp
+++ b/media/libavextensions/mediaplayerservice/AVNuUtils.cpp
@@ -277,7 +277,7 @@ status_t AVNuUtils::convertToSinkFormatIfNeeded(
         return BAD_VALUE;
     }
 
-    ALOGV("convert %zu bytes (frames %d) of format %x",
+    ALOGV("convert %zu bytes (frames %zu) of format %x",
           buffer->size(), frames, srcFormat);
 
     audio_format_t dstFormat;

--- a/media/libavextensions/stagefright/AVUtils.cpp
+++ b/media/libavextensions/stagefright/AVUtils.cpp
@@ -812,7 +812,7 @@ status_t AVUtils::HEVCMuxer::parserProfileTierLevel(const uint8_t *data, size_t 
 }
 static const uint8_t *findNextStartCode(
        const uint8_t *data, size_t length) {
-    ALOGV("findNextStartCode: %p %d", data, length);
+    ALOGV("findNextStartCode: %p %zu", data, length);
 
     size_t bytesLeft = length;
 


### PR DESCRIPTION
Change-Id: Ie4f49819ded3a6a0e308446829a109f57a607e88
